### PR TITLE
phy mtu and data_length negotiations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,9 +12,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -31,7 +31,7 @@ dependencies = [
 [[package]]
 name = "anyfmt"
 version = "0.1.0"
-source = "git+https://github.com/akiles/embassy#0a3590566d839fc32963d4756d99aa79917a1934"
+source = "git+https://github.com/akiles/embassy#2e062f562773f4f4ff978e7976c2d4b08b968a6c"
 
 [[package]]
 name = "as-slice"
@@ -184,7 +184,7 @@ dependencies = [
 [[package]]
 name = "defmt"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt?branch=main#a6dc0904872cd3f4aee5125dffc17723df3c9393"
+source = "git+https://github.com/knurling-rs/defmt?branch=main#144184a6ac614146c45122ece7c9fc698b749719"
 dependencies = [
  "defmt-macros",
  "semver 0.11.0",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "defmt-macros"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt?branch=main#a6dc0904872cd3f4aee5125dffc17723df3c9393"
+source = "git+https://github.com/knurling-rs/defmt?branch=main#144184a6ac614146c45122ece7c9fc698b749719"
 dependencies = [
  "defmt-parser",
  "proc-macro2",
@@ -204,12 +204,12 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt?branch=main#a6dc0904872cd3f4aee5125dffc17723df3c9393"
+source = "git+https://github.com/knurling-rs/defmt?branch=main#144184a6ac614146c45122ece7c9fc698b749719"
 
 [[package]]
 name = "defmt-rtt"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt?branch=main#a6dc0904872cd3f4aee5125dffc17723df3c9393"
+source = "git+https://github.com/knurling-rs/defmt?branch=main#144184a6ac614146c45122ece7c9fc698b749719"
 dependencies = [
  "cortex-m",
  "defmt",
@@ -229,7 +229,7 @@ dependencies = [
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/akiles/embassy#0a3590566d839fc32963d4756d99aa79917a1934"
+source = "git+https://github.com/akiles/embassy#2e062f562773f4f4ff978e7976c2d4b08b968a6c"
 dependencies = [
  "anyfmt",
  "cortex-m",
@@ -243,7 +243,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/akiles/embassy#0a3590566d839fc32963d4756d99aa79917a1934"
+source = "git+https://github.com/akiles/embassy#2e062f562773f4f4ff978e7976c2d4b08b968a6c"
 dependencies = [
  "darling",
  "quote",
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.1.0"
-source = "git+https://github.com/akiles/embassy#0a3590566d839fc32963d4756d99aa79917a1934"
+source = "git+https://github.com/akiles/embassy#2e062f562773f4f4ff978e7976c2d4b08b968a6c"
 dependencies = [
  "anyfmt",
  "bare-metal",
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "fixed"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7199a77adc07a67f7946fc69f1ff2f37651190949af1496506230b30e4c8784"
+checksum = "ac9066245905bb98fca1671fe6fbb1ae7f6083e824d2411c4d0f5663fec466d8"
 dependencies = [
  "typenum",
 ]
@@ -292,9 +292,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
+checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
+checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
 
 [[package]]
 name = "futures-intrusive"
@@ -332,27 +332,27 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
+checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
+checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
 
 [[package]]
 name = "futures-util"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
+checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "panic-probe"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/probe-run?branch=main#554db6b50e8048df6bd679533cd01fca1a00b570"
+source = "git+https://github.com/knurling-rs/probe-run?branch=main#50b598205c817066ba0166e34e30a6e16d52b010"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",

--- a/examples/src/bin/ble_bas_central.rs
+++ b/examples/src/bin/ble_bas_central.rs
@@ -77,12 +77,12 @@ impl gatt_client::Client for BatteryServiceClient {
 }
 
 #[task]
-async fn ble_central_task(sd: &'static Softdevice) {
+async fn ble_central_task(sd: &'static Softdevice, config: central::Config) {
     let addrs = &[Address::new_random_static([
         0x59, 0xf9, 0xb1, 0x9c, 0x01, 0xf5,
     ])];
 
-    let conn = central::connect(sd, addrs)
+    let conn = central::connect(sd, addrs, config)
         .await
         .dexpect(intern!("connect"));
     info!("connected");
@@ -161,7 +161,9 @@ fn main() -> ! {
 
     let executor = EXECUTOR.put(Executor::new(cortex_m::asm::sev));
     executor.spawn(softdevice_task(sd)).dewrap();
-    executor.spawn(ble_central_task(sd)).dewrap();
+    executor
+        .spawn(ble_central_task(sd, central::Config::default()))
+        .dewrap();
 
     loop {
         executor.run();

--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -30,7 +30,7 @@ struct BatteryService {
 }
 
 #[task]
-async fn bluetooth_task(sd: &'static Softdevice) {
+async fn bluetooth_task(sd: &'static Softdevice, config: peripheral::Config) {
     let server: BatteryService = gatt_server::register(sd).dewrap();
     #[rustfmt::skip]
     let adv_data = &[
@@ -50,6 +50,7 @@ async fn bluetooth_task(sd: &'static Softdevice) {
                 adv_data,
                 scan_data,
             },
+            config,
         )
         .await
         .dewrap();
@@ -122,7 +123,9 @@ fn main() -> ! {
 
     let executor = EXECUTOR.put(Executor::new(cortex_m::asm::sev));
     executor.spawn(softdevice_task(sd)).dewrap();
-    executor.spawn(bluetooth_task(sd)).dewrap();
+    executor
+        .spawn(bluetooth_task(sd, peripheral::Config::default()))
+        .dewrap();
 
     loop {
         executor.run();

--- a/examples/src/bin/ble_peripheral_gattspam.rs
+++ b/examples/src/bin/ble_peripheral_gattspam.rs
@@ -23,7 +23,7 @@ async fn softdevice_task(sd: &'static Softdevice) {
 }
 
 #[task]
-async fn bluetooth_task(sd: &'static Softdevice) {
+async fn bluetooth_task(sd: &'static Softdevice, config: peripheral::Config) {
     for i in 0..24 {
         let service_uuid = Uuid::new_16(0x4200 + i);
 
@@ -106,6 +106,7 @@ async fn bluetooth_task(sd: &'static Softdevice) {
                 adv_data,
                 scan_data,
             },
+            config,
         )
         .await
         .dewrap();
@@ -160,7 +161,9 @@ fn main() -> ! {
 
     let executor = EXECUTOR.put(Executor::new(cortex_m::asm::sev));
     executor.spawn(softdevice_task(sd)).dewrap();
-    executor.spawn(bluetooth_task(sd)).dewrap();
+    executor
+        .spawn(bluetooth_task(sd, peripheral::Config::default()))
+        .dewrap();
 
     loop {
         executor.run();

--- a/nrf-softdevice/src/ble/central.rs
+++ b/nrf-softdevice/src/ble/central.rs
@@ -54,8 +54,14 @@ impl From<RawError> for ConnectStopError {
 }
 
 pub(crate) static CONNECT_SIGNAL: Signal<Result<Connection, ConnectError>> = Signal::new();
+pub(crate) static MTU_UPDATED_SIGNAL: Signal<Result<(), ConnectError>> = Signal::new();
 
-pub async fn connect(sd: &Softdevice, whitelist: &[Address]) -> Result<Connection, ConnectError> {
+// Begins an ATT MTU exchange procedure, followed by a data length update request as necessary.
+pub async fn connect(
+    sd: &Softdevice,
+    whitelist: &[Address],
+    config: Config,
+) -> Result<Connection, ConnectError> {
     let (addr, fp) = match whitelist.len() {
         0 => depanic!("zero-length whitelist"),
         1 => (
@@ -109,7 +115,68 @@ pub async fn connect(sd: &Softdevice, whitelist: &[Address]) -> Result<Connectio
 
     // TODO handle future drop
 
-    CONNECT_SIGNAL.wait().await
+    let conn = CONNECT_SIGNAL.wait().await?;
+
+    let state = conn.state();
+
+    state.gap.update(|mut gap| {
+        gap.rx_phys = config.tx_phys;
+        gap.tx_phys = config.rx_phys;
+        gap
+    });
+
+    let link = state.link.update(|mut link| {
+        link.att_mtu_desired = config.att_mtu_desired;
+        link
+    });
+
+    // Begin an ATT MTU exchange if necessary.
+    if link.att_mtu_desired > link.att_mtu_effective as u16 {
+        let ret = unsafe {
+            raw::sd_ble_gattc_exchange_mtu_request(
+                state.conn_handle.get().unwrap(), //todo
+                link.att_mtu_desired,
+            )
+        };
+
+        MTU_UPDATED_SIGNAL.wait().await?;
+
+        if let Err(err) = RawError::convert(ret) {
+            warn!("sd_ble_gattc_exchange_mtu_request err {:?}", err);
+        }
+    }
+
+    // Send a data length update request if necessary.
+    #[cfg(any(feature = "s113", feature = "s132", feature = "s140"))]
+    {
+        let link = state.link.update(|mut link| {
+            link.data_length_desired = config.data_length_desired;
+            link
+        });
+
+        if link.data_length_desired > link.data_length_effective {
+            let dl_params = raw::ble_gap_data_length_params_t {
+                max_rx_octets: link.data_length_desired.into(),
+                max_tx_octets: link.data_length_desired.into(),
+                max_rx_time_us: raw::BLE_GAP_DATA_LENGTH_AUTO as u16,
+                max_tx_time_us: raw::BLE_GAP_DATA_LENGTH_AUTO as u16,
+            };
+
+            let ret = unsafe {
+                raw::sd_ble_gap_data_length_update(
+                    state.conn_handle.get().unwrap(), //todo
+                    &dl_params as *const raw::ble_gap_data_length_params_t,
+                    mem::zeroed(),
+                )
+            };
+
+            if let Err(err) = RawError::convert(ret) {
+                warn!("sd_ble_gap_data_length_update err {:?}", err);
+            }
+        }
+    }
+
+    Ok(conn)
 }
 
 pub fn connect_stop(sd: &Softdevice) -> Result<(), ConnectStopError> {
@@ -118,5 +185,30 @@ pub fn connect_stop(sd: &Softdevice) -> Result<(), ConnectStopError> {
         Ok(()) => Ok(()),
         Err(RawError::InvalidState) => Err(ConnectStopError::NotRunning),
         Err(e) => Err(e.into()),
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct Config {
+    /// Requested ATT_MTU size for the next connection that is established.
+    att_mtu_desired: u16,
+    /// The stack's default data length. <27-251>
+    #[cfg(any(feature = "s113", feature = "s132", feature = "s140"))]
+    data_length_desired: u8,
+    // bits of BLE_GAP_PHY_
+    tx_phys: u8,
+    // bits of BLE_GAP_PHY_
+    rx_phys: u8,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            att_mtu_desired: 32,
+            #[cfg(any(feature = "s113", feature = "s132", feature = "s140"))]
+            data_length_desired: 27,
+            tx_phys: raw::BLE_GAP_PHY_AUTO as u8,
+            rx_phys: raw::BLE_GAP_PHY_AUTO as u8,
+        }
     }
 }

--- a/nrf-softdevice/src/ble/peripheral.rs
+++ b/nrf-softdevice/src/ble/peripheral.rs
@@ -97,10 +97,13 @@ impl From<RawError> for AdvertiseStopError {
 
 static mut ADV_HANDLE: u8 = raw::BLE_GAP_ADV_SET_HANDLE_NOT_SET as u8;
 pub(crate) static ADV_SIGNAL: Signal<Result<Connection, AdvertiseError>> = Signal::new();
+pub(crate) static MTU_UPDATED_SIGNAL: Signal<Result<(), AdvertiseError>> = Signal::new();
 
+// Begins an ATT MTU exchange procedure, followed by a data length update request as necessary.
 pub async fn advertise(
     sd: &Softdevice,
     adv: ConnectableAdvertisement<'_>,
+    config: Config,
 ) -> Result<Connection, AdvertiseError> {
     // TODO make these configurable, only the right params based on type?
     let mut adv_params: raw::ble_gap_adv_params_t = unsafe { mem::zeroed() };
@@ -161,7 +164,62 @@ pub async fn advertise(
 
     // The advertising data needs to be kept alive for the entire duration of the advertising procedure.
 
-    ADV_SIGNAL.wait().await
+    let conn = ADV_SIGNAL.wait().await?;
+
+    let state = conn.state();
+
+    let link = state.link.update(|mut link| {
+        link.att_mtu_desired = config.att_mtu_desired;
+        link
+    });
+
+    // Begin an ATT MTU exchange if necessary.
+    if link.att_mtu_desired > link.att_mtu_effective as u16 {
+        let ret = unsafe {
+            raw::sd_ble_gattc_exchange_mtu_request(
+                state.conn_handle.get().unwrap(), //todo
+                link.att_mtu_desired,
+            )
+        };
+
+        MTU_UPDATED_SIGNAL.wait().await?;
+
+        if let Err(err) = RawError::convert(ret) {
+            warn!("sd_ble_gattc_exchange_mtu_request err {:?}", err);
+        }
+    }
+
+    // Send a data length update request if necessary.
+    #[cfg(any(feature = "s113", feature = "s132", feature = "s140"))]
+    {
+        let link = state.link.update(|mut link| {
+            link.data_length_desired = config.data_length_desired;
+            link
+        });
+
+        if link.data_length_desired > link.data_length_effective {
+            let dl_params = raw::ble_gap_data_length_params_t {
+                max_rx_octets: link.data_length_desired.into(),
+                max_tx_octets: link.data_length_desired.into(),
+                max_rx_time_us: raw::BLE_GAP_DATA_LENGTH_AUTO as u16,
+                max_tx_time_us: raw::BLE_GAP_DATA_LENGTH_AUTO as u16,
+            };
+
+            let ret = unsafe {
+                raw::sd_ble_gap_data_length_update(
+                    state.conn_handle.get().unwrap(), //todo
+                    &dl_params as *const raw::ble_gap_data_length_params_t,
+                    mem::zeroed(),
+                )
+            };
+
+            if let Err(err) = RawError::convert(ret) {
+                warn!("sd_ble_gap_data_length_update err {:?}", err);
+            }
+        }
+    }
+
+    Ok(conn)
 }
 
 pub fn advertise_stop(sd: &Softdevice) -> Result<(), AdvertiseStopError> {
@@ -170,5 +228,30 @@ pub fn advertise_stop(sd: &Softdevice) -> Result<(), AdvertiseStopError> {
         Ok(()) => Ok(()),
         Err(RawError::InvalidState) => Err(AdvertiseStopError::NotRunning),
         Err(e) => Err(e.into()),
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct Config {
+    /// Requested ATT_MTU size for the next connection that is established.
+    att_mtu_desired: u16,
+    /// The stack's default data length. <27-251>
+    #[cfg(any(feature = "s113", feature = "s132", feature = "s140"))]
+    data_length_desired: u8,
+    // bits of BLE_GAP_PHY_
+    tx_phys: u8,
+    // bits of BLE_GAP_PHY_
+    rx_phys: u8,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            att_mtu_desired: 32,
+            #[cfg(any(feature = "s113", feature = "s132", feature = "s140"))]
+            data_length_desired: 27,
+            tx_phys: raw::BLE_GAP_PHY_AUTO as u8,
+            rx_phys: raw::BLE_GAP_PHY_AUTO as u8,
+        }
     }
 }

--- a/nrf-softdevice/src/lib.rs
+++ b/nrf-softdevice/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(const_in_array_repeat_expressions)]
 #![feature(type_alias_impl_trait)]
 #![feature(const_fn)]
+#![feature(cell_update)]
 
 pub(crate) mod util;
 


### PR DESCRIPTION
closes #5 and closes #6   (eventually)



Im using S140 7.0.1 peripheral state charts
https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.s140.api.v7.0.1/group___b_l_e___g_a_p___d_a_t_a___l_e_n_g_t_h___u_p_d_a_t_e___p_r_o_c_e_d_u_r_e___m_s_c.html

https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.s140.api.v7.0.1/group___b_l_e___g_a_p___p_e_r_i_p_h_e_r_a_l___p_h_y___u_p_d_a_t_e.html


My pixel enumerates the ble_bas_peripheral example with this code
```
0.000000 INFO  Hello World!
└─ ble_bas_peripheral::__cortex_m_rt_main @ examples/src/bin/ble_bas_peripheral.rs:159
0.000001 WARN  You're giving more RAM to the softdevice than needed. You can change your app's RAM start address to 536925320
└─ nrf_softdevice::softdevice::{{impl}}::enable @ nrf-softdevice/src/softdevice.rs:283
0.000002 INFO  hi
└─ nrf_softdevice::ble::gatt_server::register @ nrf-softdevice/src/ble/gatt_server.rs:57
0.000003 INFO  Advertising started!
└─ nrf_softdevice::ble::peripheral::advertise::{{closure}} @ nrf-softdevice/src/ble/peripheral.rs:160
0.000004 TRACE on_connected conn_handle=3
└─ nrf_softdevice::ble::events::on_connected @ nrf-softdevice/src/ble/events.rs:123
0.000005 TRACE conn 0: connected
└─ nrf_softdevice::ble::connection::{{impl}}::new @ nrf-softdevice/src/ble/connection.rs:212
0.000006 INFO  advertising done!
└─ ble_bas_peripheral::__static_executor_task_bluetooth_task::{{closure}} @ examples/src/bin/ble_bas_peripheral.rs:132
0.000007 TRACE on_data_length_update_request conn_handle=3 max_rx_octets=251 max_rx_time_us=2120 max_tx_octets=27 max_tx_time_us=328
└─ nrf_softdevice::ble::events::on_data_length_update_request @ nrf-softdevice/src/ble/events.rs:300
0.000008 TRACE on_data_length_update conn_handle=3 max_rx_octets=27 max_rx_time_us=328 max_tx_octets=132 max_tx_time_us=2120
└─ nrf_softdevice::ble::events::on_data_length_update @ nrf-softdevice/src/ble/events.rs:329
0.000009 TRACE on_phy_update_request conn_handle=3 rx_phys=3 tx_phys=3
└─ nrf_softdevice::ble::events::on_phy_update_request @ nrf-softdevice/src/ble/events.rs:254
0.000010 TRACE on_phy_update conn_handle=3 status=0 rx_phy=2 tx_phy=2
└─ nrf_softdevice::ble::events::on_phy_update @ nrf-softdevice/src/ble/events.rs:282
0.000011 TRACE on_conn_param_update conn_handle=3
└─ nrf_softdevice::ble::events::on_conn_param_update @ nrf-softdevice/src/ble/events.rs:157
0.000012 TRACE on_conn_param_update conn_handle=3
└─ nrf_softdevice::ble::events::on_conn_param_update @ nrf-softdevice/src/ble/events.rs:157
```

still have to do all the negotiation logic around what user provides and what peer requests etc. 