### PR TITLE
vscode: too many files to watch by default, remove some

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,10 @@
   "rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
   "rust-analyzer.checkOnSave.allTargets": false,
   "rust-analyzer.cargo.loadOutDirsFromCheck": true,
-  "rust-analyzer.procMacro.enable": true
+  "rust-analyzer.procMacro.enable": true,
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/target/**": true,
+  }
 }


### PR DESCRIPTION
I tend to (on linux anyway) get the notification it cant watch my workspace due too too many files to watch. You can up the number of files its able to watch with some setting, but I found this somewhere once and it seems to work nicely for just removing a bunch of files you rarely would want to watch for updates for