### PR TITLE
Debug

### DIFF
--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -32,7 +32,7 @@ ble-gatt-client = []
 
 [dependencies]
 num_enum = { version = "0.5.1", default-features = false }
-embassy = { version = "0.1.0" }
+embassy = { version = "0.1.0", git = "https://github.com/akiles/embassy" }
 cortex-m = "0.6.4"
 cortex-m-rt = "0.6.13"
 heapless = "0.5.6"

--- a/nrf-softdevice/src/ble/gatt_server.rs
+++ b/nrf-softdevice/src/ble/gatt_server.rs
@@ -39,7 +39,7 @@ pub trait Server: Sized {
     fn on_write(&self, handle: u16, data: &[u8]) -> Option<Self::Event>;
 }
 
-#[derive(defmt::Format)]
+#[derive(Debug, defmt::Format)]
 pub enum RegisterError {
     Raw(RawError),
 }

--- a/nrf-softdevice/src/ble/peripheral.rs
+++ b/nrf-softdevice/src/ble/peripheral.rs
@@ -114,7 +114,7 @@ pub enum NonconnectableAdvertisement {
 }
 
 /// Error for [`advertise_start`]
-#[derive(defmt::Format)]
+#[derive(Debug, defmt::Format)]
 pub enum AdvertiseError {
     Timeout,
     Raw(RawError),

--- a/nrf-softdevice/src/raw_error.rs
+++ b/nrf-softdevice/src/raw_error.rs
@@ -5,7 +5,7 @@ use crate::raw;
 /// All possible errors returned by softdevice calls.
 #[rustfmt::skip]
 #[repr(u32)]
-#[derive(defmt::Format, IntoPrimitive, FromPrimitive)]
+#[derive(Debug, defmt::Format, IntoPrimitive, FromPrimitive)]
 pub enum RawError {
     /// This is not really an error, but is added here anyway, just in case someone mistakenly converts NRF_SUCCESS into RawError.
     Success = raw::NRF_SUCCESS,


### PR DESCRIPTION
Attempting to disable defmt for use on a dongle.

defmt isnt actually a feature so it cant actually be disabled. I always have to keep the linker
https://github.com/jacobrosenthal/nrf-softdevice/commit/cf0f150713d43baa764773d2eabcab93a58127ef#diff-f6009bd0d260464389ace37ab2f89adae993e1fa4a47f779e4c9859937005cedR9
Ideally just like embassy, defmt could be off entirely and you wouldnt need the linker.

But if I do leave the linker, and use .unwrap() in main, a few things fail because a few things dont derive debug. Probably more stuff needs debug? but this is all I ran into.

Also embassy isnt published yet so turn that into git.

