### PR TITLE
Improvements to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,10 +16,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
         target: thumbv7em-none-eabihf
         override: true
+        components: rustfmt
+
     - name: Build
       run: ./test-build.sh
+
+    - name: Format
+      run: cargo fmt --verbose
+


### PR DESCRIPTION
Introduces a cache for builds and invokes `rustfmt`, failing if there are formatting issues.