### PR TITLE
Add support for `write_without_response` on server characteristics.

### DIFF
--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -25,6 +25,8 @@ struct CharacteristicArgs {
     #[darling(default)]
     write: bool,
     #[darling(default)]
+    write_without_response: bool,
+    #[darling(default)]
     notify: bool,
     #[darling(default)]
     indicate: bool,
@@ -221,6 +223,7 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
         let uuid = ch.args.uuid;
         let read = ch.args.read;
         let write = ch.args.write;
+        let write_without_response = ch.args.write_without_response;
         let notify = ch.args.notify;
         let indicate = ch.args.indicate;
         let ty = &ch.ty;
@@ -240,6 +243,7 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
                     uuid: #uuid,
                     can_read: #read,
                     can_write: #write,
+                    can_write_without_response: #write_without_response,
                     can_notify: #notify,
                     can_indicate: #indicate,
                     max_len: #ty_as_val::MAX_SIZE as _,
@@ -281,7 +285,7 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
             ));
         }
 
-        if write {
+        if write || write_without_response {
             let case_write = format_ident!("{}Write", name_pascal);
             code_event_enum.extend(quote_spanned!(ch.span=>
                 #case_write(#ty),

--- a/nrf-softdevice/src/ble/gatt_server.rs
+++ b/nrf-softdevice/src/ble/gatt_server.rs
@@ -15,6 +15,7 @@ pub struct Characteristic {
     pub uuid: Uuid,
     pub can_read: bool,
     pub can_write: bool,
+    pub can_write_without_response: bool,
     pub can_notify: bool,
     pub can_indicate: bool,
     pub max_len: usize,
@@ -107,6 +108,9 @@ pub fn register_service<S: Service>(_sd: &Softdevice) -> Result<S, RegisterError
         let mut char_md: raw::ble_gatts_char_md_t = unsafe { mem::zeroed() };
         char_md.char_props.set_read(char.can_read as u8);
         char_md.char_props.set_write(char.can_write as u8);
+        char_md
+            .char_props
+            .set_write_wo_resp(char.can_write_without_response as u8);
         char_md.char_props.set_notify(char.can_notify as u8);
         char_md.char_props.set_indicate(char.can_indicate as u8);
         char_md.p_cccd_md = &mut cccd_attr_md;


### PR DESCRIPTION
Sets the appropriate flag in the Softdevice database.