### PR TITLE
Updating to heapless 0.9

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -53,7 +53,7 @@ nrf-softdevice = { version = "0.1.0", path = "../nrf-softdevice", features = ["d
 embedded-storage = "0.3.1"
 embedded-storage-async = "0.4.1"
 futures = { version = "0.3.29", default-features = false }
-heapless = "0.8.0"
+heapless = "0.9"
 atomic-pool = "1.0.1"
 static_cell = "2.0.0"
 

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -13,6 +13,8 @@ rust-version = "1.76"
 [features]
 default = ["macros"]
 
+defmt = ["dep:defmt", "heapless/defmt"]
+
 nrf52805 = []
 nrf52810 = []
 nrf52811 = []
@@ -61,10 +63,10 @@ log = { version = "0.4.11", optional = true }
 critical-section = { version = "1.0", optional = true }
 
 num_enum = { version = "0.7.0", default-features = false }
-embassy-sync = { version = "0.6.0" }
+embassy-sync = { version = "0.8.0" }
 embassy-futures = { version = "0.1.1" }
 cortex-m = "0.7.2"
-heapless = "0.8.0"
+heapless = "0.9"
 fixed = "1.5.0"
 futures = { version = "0.3.17", default-features = false }
 embedded-storage = "0.3.1"


### PR DESCRIPTION
Updating embassy-sync to 0.8, so it also uses heapless 0.9