### PR TITLE
Match characteristics based on their flags (read/write/notify/...)

### DIFF
--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -586,6 +586,7 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
         let uuid = ch.args.uuid;
         let read = ch.args.read;
         let write = ch.args.write;
+        let write_without_response = ch.args.write_without_response;
         let notify = ch.args.notify;
         let indicate = ch.args.indicate;
         let ty = &ch.ty;
@@ -623,8 +624,14 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
 
         code_disc_char.extend(quote_spanned!(ch.span=>
             if let Some(char_uuid) = characteristic.uuid {
-                if char_uuid == self.#uuid_field {
-                    // TODO maybe check the char_props have the necessary operations allowed? read/write/notify/etc
+                if self.#value_handle == 0
+                    && char_uuid == self.#uuid_field
+                    && (!#read || characteristic.props.read() != 0)
+                    && (!#write || characteristic.props.write() != 0)
+                    && (!#write_without_response || characteristic.props.write_wo_resp() != 0)
+                    && (!#notify || characteristic.props.notify() != 0)
+                    && (!#indicate || characteristic.props.indicate() != 0)
+                {
                     self.#value_handle = characteristic.handle_value;
                     for desc in descriptors {
                         if let Some(_desc_uuid) = desc.uuid {
@@ -657,6 +664,11 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
                     let buf = #ty_as_val::to_gatt(val);
                     #ble::gatt_client::write(&self.conn, self.#value_handle, buf).await
                 }
+            ));
+        }
+
+        if write_without_response {
+            code_impl.extend(quote_spanned!(ch.span=>
                 #fn_vis async fn #write_wor_fn(&self, val: &#ty) -> Result<(), #ble::gatt_client::WriteError> {
                     let buf = #ty_as_val::to_gatt(val);
                     #ble::gatt_client::write_without_response(&self.conn, self.#value_handle, buf).await


### PR DESCRIPTION
Some BLE devices expose multiple characteristics with the same UUID but different properties. For example, HID over BLE devices have two characteristics with UUID 0x2A4D:
  - one with read + notify flags - input endpoint (keypresses, stick movements)
  - one with write-without-response flag - output endpoint  (haptics)

Currently the discovery loop matches UUID only, not only that but it re-assigns the characteristic on each match, so only the last discovered characteristic is made available to the user. This makes it impossible to access both endpoints.

After the change, something like this is possible:

```
#[gatt_client(uuid = "1812")]
pub struct XboxHidServiceClient {
    #[characteristic(uuid = "2a4d", read, notify)]
    pub hid_report: [u8; 16],

    #[characteristic(uuid = "2a4d", write_without_response)]
    pub hid_output_report: [u8; 8],
}
```

The idea is that if user requests a certain operation flag, it must be presented in props of the matching characteristic.
Also added a small guard to not re-assign chars that already have a handle.